### PR TITLE
fix: add missing network protocol for metamask addChain

### DIFF
--- a/packages/frontend/src/hooks/useEthers.ts
+++ b/packages/frontend/src/hooks/useEthers.ts
@@ -48,7 +48,7 @@ export default function useEthers({ subnet, viaMetaMask }: Args = {}) {
                     symbol: subnet.currencySymbol,
                     decimals: 18,
                   },
-                  rpcUrls: [subnet.endpoint],
+                  rpcUrls: [`http://${subnet.endpoint}`],
                 })
               }
             }


### PR DESCRIPTION
# Description

The network protocol (http, ws, etc.) was recently removed from what is expected to be filled in `subnet.endpoint` throughout the platform. This change introduced a bug in the `metamask.addChain` call which was missing the `http` protocol in the new network rpc endpoint for it to work.

This PR adds the missing `http` network protocol in the network endpoint field.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
