### PR TITLE
fix: remove log parsing errors

### DIFF
--- a/packages/frontend/src/components/steps/Step2.tsx
+++ b/packages/frontend/src/components/steps/Step2.tsx
@@ -154,12 +154,7 @@ const Step2 = ({ onFinish }: StepProps) => {
                   tokenSentLogIndex = log.logIndex
                   break
                 }
-              } catch (error) {
-                setErrors((e) => [
-                  ...e,
-                  `Error when parsing receipt logs to find TokenSent event!`,
-                ])
-              }
+              } catch {}
             }
 
             if (tokenSentLogIndex == undefined) {


### PR DESCRIPTION
# Description

This PR fixes the log parsing errors that were introduced with #22 when decoding receipt's logs. Failed decoding should not have triggered frontend errors as they are expected (happening when trying to decode TokenSent events with unrelated events in the loop).

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
