### PR TITLE
feat: handle case when user has 0 balance

### DIFF
--- a/packages/frontend/src/components/steps/Step1.tsx
+++ b/packages/frontend/src/components/steps/Step1.tsx
@@ -171,7 +171,7 @@ const Step1 = ({ onFinish, onPrev }: StepProps) => {
           <SubnetSelect
             placeholder="Select a subnet"
             loading={receivingSubnetLoading}
-            disabled={!token || receivingSubnetLoading}
+            disabled={!token || receivingSubnetLoading || balance === '0.0'}
             subnets={subnetsWithoutSendingOne}
           />
         </Form.Item>
@@ -195,7 +195,9 @@ const Step1 = ({ onFinish, onPrev }: StepProps) => {
             },
           ]}
         >
-          <Input disabled={!token || receivingSubnetLoading} />
+          <Input
+            disabled={!token || receivingSubnetLoading || balance === '0.0'}
+          />
         </Form.Item>
         <Form.Item
           label="Amount"
@@ -208,7 +210,7 @@ const Step1 = ({ onFinish, onPrev }: StepProps) => {
           ]}
         >
           <InputNumber
-            disabled={!token || receivingSubnetLoading}
+            disabled={!token || receivingSubnetLoading || balance === '0.0'}
             addonAfter={token?.symbol}
             max={balance}
           />
@@ -223,7 +225,7 @@ const Step1 = ({ onFinish, onPrev }: StepProps) => {
             id="nextButton"
             type="primary"
             htmlType="submit"
-            disabled={!token || receivingSubnetLoading}
+            disabled={!token || receivingSubnetLoading || balance === '0.0'}
           >
             Next
           </Button>


### PR DESCRIPTION
# Description

This PR makes form fields of the 2nd form disabled if user selected a token they don't own (balance `0`).

Fixes TOO-327

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
