### PR TITLE
fix: make traceparent source spans sync

### DIFF
--- a/packages/frontend/src/components/steps/Step2.tsx
+++ b/packages/frontend/src/components/steps/Step2.tsx
@@ -141,12 +141,15 @@ const Step2 = ({ onFinish }: StepProps) => {
           if (proof && trie) {
             const sendExecutorServiceSpan = apmTransaction?.startSpan(
               'send-request-to-executor-service',
-              'app'
+              'app',
+              { sync: true }
             )
 
-            const traceparent = `00-${
-              (sendExecutorServiceSpan as any).traceId
-            }-${(sendExecutorServiceSpan as any).id}-01`
+            const traceparent = sendExecutorServiceSpan
+              ? `00-${(sendExecutorServiceSpan as any).traceId}-${
+                  (sendExecutorServiceSpan as any).id
+                }-01`
+              : ''
 
             const iface = new ethers.utils.Interface(ERC20MessagingJSON.abi)
             let tokenSentLogIndex: number | undefined = undefined
@@ -185,12 +188,15 @@ const Step2 = ({ onFinish }: StepProps) => {
                 sendExecutorServiceSpan?.end()
                 const observeExecutorJobSpan = apmTransaction?.startSpan(
                   'wait-for-executor-service-job-execution',
-                  'app'
+                  'app',
+                  { sync: true }
                 )
 
-                const traceparent = `00-${
-                  (observeExecutorJobSpan as any).traceId
-                }-${(observeExecutorJobSpan as any).id}-01`
+                const traceparent = observeExecutorJobSpan
+                  ? `00-${(observeExecutorJobSpan as any).traceId}-${
+                      (observeExecutorJobSpan as any).id
+                    }-01`
+                  : ''
 
                 observeExecutorServiceJob(job.id, { traceparent }).subscribe({
                   next: (progress: number) => {


### PR DESCRIPTION
# Description

This PR fixes Elastic APM traceparent generation from certain spans by making the later synchronous.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
