### PR TITLE
feat: filter registered subnets internal only

### DIFF
--- a/packages/frontend/src/hooks/useRegisteredSubnets.test.ts
+++ b/packages/frontend/src/hooks/useRegisteredSubnets.test.ts
@@ -21,6 +21,13 @@ const registeredSubnets: { [x: string]: Subnet } = {
     logoURL: '',
     name: 'subnetMock',
   },
+  incal: {
+    chainId: BigNumber.from(2),
+    currencySymbol: 'TST2',
+    endpoint: '',
+    logoURL: '',
+    name: 'Incal',
+  },
 }
 
 const subnetIdsByIndexes = ['subnet1', 'subnet2']
@@ -78,6 +85,8 @@ describe('useRegisteredSubnets', () => {
     expect(subnetsMock).toHaveBeenCalledWith('subnet1')
     expect(subnetsMock).toHaveBeenCalledWith('subnet2')
     expect(result.current.loading).toBe(false)
-    expect(result.current.registeredSubnets).toStrictEqual(expectedSubnets)
+    expect(result.current.registeredSubnets).toStrictEqual(
+      expectedSubnets.filter((s) => s.name === 'Incal')
+    )
   })
 })

--- a/packages/frontend/src/hooks/useRegisteredSubnets.ts
+++ b/packages/frontend/src/hooks/useRegisteredSubnets.ts
@@ -66,7 +66,7 @@ export default function useRegisteredSubnets() {
         values
           .filter((v) => v.status === 'fulfilled')
           .map((v) => (v.status === 'fulfilled' ? v.value : undefined))
-          .filter((v) => v)
+          .filter((v) => v && v.name === 'Incal')
       )
       setRegisteredSubnets(subnets as SubnetWithId[])
     }


### PR DESCRIPTION
# Description

This PR adds a filter in the `useRegisteredSubnets` hook so that only `Incal` gets returned, as a temporary solution for external subnets not to be used in the dapp (temporary solution until we have permissionless subnet registration).

Fixes TOO-359

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
