### PR TITLE
feat: remove unused address when registering tokens

### DIFF
--- a/packages/frontend/src/hooks/useRegisterToken.test.ts
+++ b/packages/frontend/src/hooks/useRegisterToken.test.ts
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react'
 import { vi } from 'vitest'
 
 import * as contractExports from '../contracts'
-import useRegisterToken, { zeroAddress } from './useRegisterToken'
+import useRegisterToken from './useRegisterToken'
 import { ethers } from 'ethers'
 
 const deployTokenMock = vi
@@ -40,12 +40,11 @@ describe('registerToken', () => {
     const supply = 1_000
 
     const params = ethers.utils.defaultAbiCoder.encode(
-      ['string', 'string', 'uint256', 'address', 'uint256', 'uint256'],
+      ['string', 'string', 'uint256', 'uint256', 'uint256'],
       [
         name,
         symbol,
         ethers.utils.parseUnits(cap.toString()),
-        zeroAddress,
         ethers.utils.parseUnits(dailyMintLimit.toString()),
         ethers.utils.parseUnits(supply.toString()),
       ]

--- a/packages/frontend/src/hooks/useRegisterToken.ts
+++ b/packages/frontend/src/hooks/useRegisterToken.ts
@@ -6,8 +6,6 @@ import { ErrorsContext } from '../contexts/errors'
 import { erc20MessagingContract } from '../contracts'
 import useEthers from './useEthers'
 
-export const zeroAddress = '0x0000000000000000000000000000000000000000'
-
 export default function useRegisterToken() {
   const { provider } = useEthers({
     viaMetaMask: true,
@@ -25,12 +23,11 @@ export default function useRegisterToken() {
       setLoading(true)
 
       const params = ethers.utils.defaultAbiCoder.encode(
-        ['string', 'string', 'uint256', 'address', 'uint256', 'uint256'],
+        ['string', 'string', 'uint256', 'uint256', 'uint256'],
         [
           name,
           symbol,
           ethers.utils.parseUnits(cap.toString()),
-          zeroAddress,
           ethers.utils.parseUnits(dailyMintLimit.toString()),
           ethers.utils.parseUnits(supply.toString()),
         ]


### PR DESCRIPTION
# Description

This PR removes the unused zero address in the `useRegisterToken` hook.
It follows https://github.com/topos-protocol/topos-smart-contracts/pull/114

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
