### PR TITLE
fix: add missing coverage main branch trigger

### DIFF
--- a/.github/workflows/test:coverage.yml
+++ b/.github/workflows/test:coverage.yml
@@ -1,6 +1,9 @@
 name: Run test coverage
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
# Description

This PR adds a missing CI trigger for test coverage on `main` pushes.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
