### PR TITLE
fix: better handle token registration errors

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -61,7 +61,7 @@ const App = () => {
             const subnetId = await contract.networkSubnetId()
 
             toposSubnet = {
-              chainId: chainId,
+              chainId,
               endpointHttp: toposSubnetEndpointHttp,
               endpointWs: toposSubnetEndpointWs,
               currencySymbol: 'TOPOS',

--- a/packages/frontend/src/components/RegisterToken.tsx
+++ b/packages/frontend/src/components/RegisterToken.tsx
@@ -11,6 +11,7 @@ import { ERROR, SUCCESS } from '../constants/wordings'
 import { MultiStepFormContext } from '../contexts/multiStepForm'
 import useRegisterToken from '../hooks/useRegisterToken'
 import TestId from '../utils/testId'
+import { ErrorsContext } from '../contexts/errors'
 
 export interface Values {
   cap: number
@@ -26,10 +27,10 @@ interface RegisterTokenFormProps {
 }
 
 const RegisterTokenForm = ({ open, setOpen }: RegisterTokenFormProps) => {
-  const [loading, setLoading] = useState(false)
+  const { setErrors } = useContext(ErrorsContext)
   const { registeredTokens } = useContext(MultiStepFormContext)
   const [form] = Form.useForm()
-  const { registerToken } = useRegisterToken()
+  const { loading, registerToken } = useRegisterToken()
 
   const onCancel = useCallback(() => {
     setOpen(false)
@@ -51,14 +52,15 @@ const RegisterTokenForm = ({ open, setOpen }: RegisterTokenFormProps) => {
         form
           .validateFields()
           .then((values) => {
-            setLoading(true)
-
-            registerToken(values).then(() => {
-              message.success(SUCCESS.REGISTERED_TOKEN)
-              setLoading(false)
-              form.resetFields()
-              setOpen(false)
-            })
+            registerToken(values)
+              .then(() => {
+                message.success(SUCCESS.REGISTERED_TOKEN)
+                form.resetFields()
+                setOpen(false)
+              })
+              .catch((error) => {
+                setErrors((e) => [...e, error])
+              })
           })
           .catch((info) => {
             console.log('Validate Failed:', info)

--- a/packages/frontend/src/hooks/useRegisterToken.test.ts
+++ b/packages/frontend/src/hooks/useRegisterToken.test.ts
@@ -59,7 +59,9 @@ describe('registerToken', () => {
         supply,
       })
       .then(() => {
-        expect(deployTokenMock).toHaveBeenCalledWith(params)
+        expect(deployTokenMock).toHaveBeenCalledWith(params, {
+          gasLimit: 5_000_000,
+        })
       })
       .finally(() => {
         expect(result.current.loading).toBe(false)


### PR DESCRIPTION
# Description

This PR fixes the token registration error handling.

The problem was that without an explicit `gasLimit`, the token registration transaction would fail without clear error in case of for instance insufficient funds. This came from the lack of explicit `gasLimit` in that transaction sending (gas estimation isn't working well with custom params).

The PR also introduces a design change: the top-context `setErrors` helper function is now called in the component rather than the hook. This may be replicated to all other hooks in the future, as the presentation layer should cover the error display.

Fixes TOO-410

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
